### PR TITLE
Expand heat map

### DIFF
--- a/src/main/java/com/google/sps/servlets/CasesDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/CasesDataServlet.java
@@ -139,6 +139,7 @@ public class CasesDataServlet extends HttpServlet {
   private void addReport(Collection<Report> reports, String[] cells, int commaFlag) {
     double lat = Double.parseDouble(cells[5 + commaFlag]);
     double lng = Double.parseDouble(cells[6 + commaFlag]);
+    double perCap = 0.0;
     int active = 0;
     int confirmed = 0;
     int deaths = 0;
@@ -166,7 +167,11 @@ public class CasesDataServlet extends HttpServlet {
     if (territory.substring(0, 1).equals("\"")) { // Some countries have " in name, remove the "
       territory = territory.substring(1);
     }
-    reports.add(new Report(territory, lat, lng, active, confirmed, deaths, recovered));
+    if (!(cells[cells.length - 2].equals("") || confirmed == 0)) { // Cases per 100,000 persons
+      perCap = Double.parseDouble(cells[cells.length - 2]);
+      System.out.println(perCap);
+    }
+    reports.add(new Report(territory, lat, lng, active, confirmed, deaths, recovered, perCap));
   }
 
   /**
@@ -177,13 +182,14 @@ public class CasesDataServlet extends HttpServlet {
     private String territory;
     private double lat;
     private double lng;
+    private double perCap;
     private int active;
     private int confirmed;
     private int deaths;
     private int recovered;
 
     public Report(String territory, double lat, double lng, int active, int confirmed, int deaths,
-        int recovered) {
+        int recovered, double perCap) {
       this.territory = territory;
       this.lat = lat;
       this.lng = lng;
@@ -191,6 +197,7 @@ public class CasesDataServlet extends HttpServlet {
       this.confirmed = confirmed;
       this.deaths = deaths;
       this.recovered = recovered;
+      this.perCap = perCap;
     }
   }
 }

--- a/src/main/java/com/google/sps/servlets/CasesDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/CasesDataServlet.java
@@ -169,14 +169,13 @@ public class CasesDataServlet extends HttpServlet {
     }
     if (!(cells[cells.length - 2].equals("") || confirmed == 0)) { // Cases per 100,000 persons
       perCap = Double.parseDouble(cells[cells.length - 2]);
-      System.out.println(perCap);
     }
     reports.add(new Report(territory, lat, lng, active, confirmed, deaths, recovered, perCap));
   }
 
   /**
-   * Represents number of active, confirmed, deaths, and recovered cases
-   * at a specific lat lng point
+   * Represents number of active, confirmed, deaths, recovered, and per-capita cases
+   * at a specific lat lng point in a territory
    */
   class Report {
     private String territory;

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -32,12 +32,6 @@
       <input type="text" placeholder="Latitude" id="latitude" readonly />
       <input type="text" placeholder="Longitude" id="longitude" readonly />
     </div>
-    <button type="button" id="toggle-heat">Toogle Heatmap</button>
-    <button type="button" id="toggle-confirmed">Show Confirmed Cases Heatmap</button>
-    <button type="button" id="toggle-active">Show Active Cases Heatmap</button>
-    <button type="button" id="toggle-deaths">Show Deaths Heatmap</button>
-    <button type="button" id="toggle-recovered">Show Recovered Heatmap</button>
-    <button type="button" id="toggle-population">Show Per-Capita Confirmed Cases Heatmap</button>
     <button type="button" id="my-location">Go to my location</button>
     <button type="button" id="videos">Show Videos</button>
 
@@ -48,5 +42,14 @@
       <p id="displayDeaths"></p>
       <p id="displayRecovered"></p>
     </div>
+
+    <button type="button" id="toggle-heat">Toogle Heatmap</button>
+    <select id="heatMapType" onchange="changeHeat()">
+      <option value="confirmed">Show Confirmed Cases Heatmap </option>
+      <option value="active">Show Active Cases Heatmap </option>
+      <option value="deaths">Show Number of Deaths Heatmap </option>
+      <option value="recovered">Show Recovered Cases Heatmap </option>
+      <option value="population">Show Per-Capita Cases Heatmap </option>
+    </select>
   </body>
 </html>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -43,7 +43,7 @@
       <p id="displayRecovered"></p>
     </div>
 
-    <button type="button" id="toggle-heat">Toogle Heatmap</button>
+    <button type="button" id="toggle-heat">Toggle Heatmap</button>
     <select id="heatMapType">
       <option value="confirmed">Show Confirmed Cases Heatmap </option>
       <option value="active">Show Active Cases Heatmap </option>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -32,6 +32,7 @@
       <input type="text" placeholder="Latitude" id="latitude" readonly />
       <input type="text" placeholder="Longitude" id="longitude" readonly />
     </div>
+    <button type="button" id="toggle-heat">Toogle Heatmap</button>
     <button type="button" id="my-location">Go to my location</button>
     <button type="button" id="videos">Show Videos</button>
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -44,7 +44,7 @@
     </div>
 
     <button type="button" id="toggle-heat">Toogle Heatmap</button>
-    <select id="heatMapType" onchange="changeHeat()">
+    <select id="heatMapType">
       <option value="confirmed">Show Confirmed Cases Heatmap </option>
       <option value="active">Show Active Cases Heatmap </option>
       <option value="deaths">Show Number of Deaths Heatmap </option>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -33,6 +33,11 @@
       <input type="text" placeholder="Longitude" id="longitude" readonly />
     </div>
     <button type="button" id="toggle-heat">Toogle Heatmap</button>
+    <button type="button" id="toggle-confirmed">Show Confirmed Cases Heatmap</button>
+    <button type="button" id="toggle-active">Show Active Cases Heatmap</button>
+    <button type="button" id="toggle-deaths">Show Deaths Heatmap</button>
+    <button type="button" id="toggle-recovered">Show Recovered Heatmap</button>
+    <button type="button" id="toggle-population">Show Per-Capita Confirmed Cases Heatmap</button>
     <button type="button" id="my-location">Go to my location</button>
     <button type="button" id="videos">Show Videos</button>
 

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -113,6 +113,12 @@ function displayCurrentStats(location, active, confirmed, deaths, recovered) {
       `Recovered: ${recovered}`;
 }
 
+
+const confirmedHeatmapData = [];
+const activeHeatmapData = [];
+const deathsHeatmapData = [];
+const recoveredHeatmapData = [];
+const populationHeatmapData = [];
 // Create a map zoomed in on Googleplex
 function createMap() {
   map = new google.maps.Map(
@@ -120,20 +126,41 @@ function createMap() {
       {center: {lat: 39.496, lng: -99.031}, zoom: 5});
   // Gets active case data and displays as heat map
   fetch('/report').then((response) => response.json()).then((reports) => {
-    const heatmapData = [];
     reports.forEach((report) => {
-      heatmapData.push({
+      confirmedHeatmapData.push({
         location: new google.maps.LatLng(report.lat, report.lng),
         weight: report.confirmed,
       });
+      if (report.active > -1) {
+        activeHeatmapData.push({
+          location: new google.maps.LatLng(report.lat, report.lng),
+          weight: report.active,
+        });
+      }
+      deathsHeatmapData.push({
+        location: new google.maps.LatLng(report.lat, report.lng),
+        weight: report.deaths,
+      });
+      recoveredHeatmapData.push({
+        location: new google.maps.LatLng(report.lat, report.lng),
+        weight: report.recovered,
+      });
+      // populationHeatmapData.push({
+      // location: new google.maps.LatLng(report.lat, report.lng),
+      // weight: report.perCap,
+      //});
       // Calculate worldwide data
       globalActive += report.active;
       globalConfirmed += report.confirmed;
       globalDeaths += report.deaths;
       globalRecovered += report.recovered;
     });
-    heatmap = new google.maps.visualization.HeatmapLayer(
-        {data: heatmapData, dissipating: false, map: map, radius: 2.5});
+    heatmap = new google.maps.visualization.HeatmapLayer({
+      data: confirmedHeatmapData,
+      dissipating: false,
+      map: map,
+      radius: 2.5
+    });
     // Display worldwide data initially
     displayCurrentStats(
         'Worldwide', globalActive, globalConfirmed, globalDeaths,
@@ -146,6 +173,37 @@ function createMap() {
       heatmap.setMap(map);
     } else {
       heatmap.setMap(null);
+    }
+  }
+
+  // Switch heatmap to show confirmed cases
+  function setHeatConfirmed(heatmap, confirmedHeatmapData) {
+    if (heatmap.getData() != confirmedHeatmapData) {
+      heatmap.setData(confirmedHeatmapData);
+    }
+  }
+  // Switch heatmap to show confirmed cases
+  function setHeatActive(heatmap, activeHeatmapData) {
+    if (heatmap.getData() != activeHeatmapData) {
+      heatmap.setData(activeHeatmapData);
+    }
+  }
+  // Switch heatmap to show confirmed cases
+  function setHeatDeaths(heatmap, deathsHeatmapData) {
+    if (heatmap.getData() != deathsHeatmapData) {
+      heatmap.setData(deathsHeatmapData);
+    }
+  }
+  // Switch heatmap to show confirmed cases
+  function setHeatRecovered(heatmap, recoveredHeatmapData) {
+    if (heatmap.getData() != recoveredHeatmapData) {
+      heatmap.setData(recoveredHeatmapData);
+    }
+  }
+  // Switch heatmap to show confirmed cases
+  function setHeatPopulation(heatmap, populationHeatmapData) {
+    if (heatmap.getData() != populationHeatmapData) {
+      heatmap.setData(populationHeatmapData);
     }
   }
 
@@ -166,6 +224,21 @@ function createMap() {
   });
   document.getElementById('toggle-heat').addEventListener('click', () => {
     toggleHeatMap(heatmap);
+  });
+  document.getElementById('toggle-confirmed').addEventListener('click', () => {
+    setHeatConfirmed(heatmap, confirmedHeatmapData);
+  });
+  document.getElementById('toggle-active').addEventListener('click', () => {
+    setHeatActive(heatmap, activeHeatmapData);
+  });
+  document.getElementById('toggle-deaths').addEventListener('click', () => {
+    setHeatDeaths(heatmap, deathsHeatmapData);
+  });
+  document.getElementById('toggle-recovered').addEventListener('click', () => {
+    setHeatRecovered(heatmap, recoveredHeatmapData);
+  });
+  document.getElementById('toggle-population').addEventListener('click', () => {
+    setHeatPopulation(heatmap, populationHeatmapData);
   });
   document.onkeypress = function(keyPressed) {
     const keyCodeForEnter = 13;

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -119,7 +119,6 @@ const activeHeatmapData = [];
 const deathsHeatmapData = [];
 const recoveredHeatmapData = [];
 const populationHeatmapData = [];
-let heatmap;
 // Create a map zoomed in on Googleplex
 function createMap() {
   map = new google.maps.Map(
@@ -161,7 +160,7 @@ function createMap() {
       data: confirmedHeatmapData,
       dissipating: false,
       map: map,
-      radius: 2.5
+      radius: 2.5,
     });
     // Display worldwide data initially
     displayCurrentStats(
@@ -186,6 +185,9 @@ function createMap() {
   });
   document.getElementById('toggle-heat').addEventListener('click', () => {
     toggleHeatMap();
+  });
+  document.getElementById('heatMapType').addEventListener('change', () => {
+    changeHeat();
   });
   document.onkeypress = function(keyPressed) {
     const keyCodeForEnter = 13;

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -113,18 +113,19 @@ function displayCurrentStats(location, active, confirmed, deaths, recovered) {
       `Recovered: ${recovered}`;
 }
 
-
+// Initialize heat maps
 const confirmedHeatmapData = [];
 const activeHeatmapData = [];
 const deathsHeatmapData = [];
 const recoveredHeatmapData = [];
 const populationHeatmapData = [];
+let heatmap;
 // Create a map zoomed in on Googleplex
 function createMap() {
   map = new google.maps.Map(
       document.getElementById('map'),
       {center: {lat: 39.496, lng: -99.031}, zoom: 5});
-  // Gets active case data and displays as heat map
+  // Gets case data and creates heat maps
   fetch('/report').then((response) => response.json()).then((reports) => {
     reports.forEach((report) => {
       confirmedHeatmapData.push({
@@ -155,6 +156,7 @@ function createMap() {
       globalDeaths += report.deaths;
       globalRecovered += report.recovered;
     });
+    // Initially display confirmed cases heat map
     heatmap = new google.maps.visualization.HeatmapLayer({
       data: confirmedHeatmapData,
       dissipating: false,
@@ -166,46 +168,6 @@ function createMap() {
         'Worldwide', globalActive, globalConfirmed, globalDeaths,
         globalRecovered);
   });
-
-  // Switch heat on and off
-  function toggleHeatMap(heatmap) {
-    if (heatmap.getMap() == null) {
-      heatmap.setMap(map);
-    } else {
-      heatmap.setMap(null);
-    }
-  }
-
-  // Switch heatmap to show confirmed cases
-  function setHeatConfirmed(heatmap, confirmedHeatmapData) {
-    if (heatmap.getData() != confirmedHeatmapData) {
-      heatmap.setData(confirmedHeatmapData);
-    }
-  }
-  // Switch heatmap to show confirmed cases
-  function setHeatActive(heatmap, activeHeatmapData) {
-    if (heatmap.getData() != activeHeatmapData) {
-      heatmap.setData(activeHeatmapData);
-    }
-  }
-  // Switch heatmap to show confirmed cases
-  function setHeatDeaths(heatmap, deathsHeatmapData) {
-    if (heatmap.getData() != deathsHeatmapData) {
-      heatmap.setData(deathsHeatmapData);
-    }
-  }
-  // Switch heatmap to show confirmed cases
-  function setHeatRecovered(heatmap, recoveredHeatmapData) {
-    if (heatmap.getData() != recoveredHeatmapData) {
-      heatmap.setData(recoveredHeatmapData);
-    }
-  }
-  // Switch heatmap to show confirmed cases
-  function setHeatPopulation(heatmap, populationHeatmapData) {
-    if (heatmap.getData() != populationHeatmapData) {
-      heatmap.setData(populationHeatmapData);
-    }
-  }
 
   const geocoder = new google.maps.Geocoder();
   document.getElementById('search-submit').addEventListener('click', () => {
@@ -223,22 +185,7 @@ function createMap() {
     searchForVideos(map);
   });
   document.getElementById('toggle-heat').addEventListener('click', () => {
-    toggleHeatMap(heatmap);
-  });
-  document.getElementById('toggle-confirmed').addEventListener('click', () => {
-    setHeatConfirmed(heatmap, confirmedHeatmapData);
-  });
-  document.getElementById('toggle-active').addEventListener('click', () => {
-    setHeatActive(heatmap, activeHeatmapData);
-  });
-  document.getElementById('toggle-deaths').addEventListener('click', () => {
-    setHeatDeaths(heatmap, deathsHeatmapData);
-  });
-  document.getElementById('toggle-recovered').addEventListener('click', () => {
-    setHeatRecovered(heatmap, recoveredHeatmapData);
-  });
-  document.getElementById('toggle-population').addEventListener('click', () => {
-    setHeatPopulation(heatmap, populationHeatmapData);
+    toggleHeatMap();
   });
   document.onkeypress = function(keyPressed) {
     const keyCodeForEnter = 13;
@@ -246,6 +193,31 @@ function createMap() {
       searchForVideos(map);
     }
   };
+}
+
+// Switch heat on and off
+function toggleHeatMap() {
+  if (heatmap.getMap() == null) {
+    heatmap.setMap(map);
+  } else {
+    heatmap.setMap(null);
+  }
+}
+
+// Switch heatmap to show user chosen statistic
+function changeHeat() {
+  const userChoice = document.getElementById('heatMapType').value;
+  if (userChoice == 'confirmed') {
+    heatmap.setData(confirmedHeatmapData);
+  } else if (userChoice == 'active') {
+    heatmap.setData(activeHeatmapData);
+  } else if (userChoice == 'deaths') {
+    heatmap.setData(deathsHeatmapData);
+  } else if (userChoice == 'recovered') {
+    heatmap.setData(recoveredHeatmapData);
+  } else if (userChoice == 'population') {
+    heatmap.setData(populationHeatmapData);
+  }
 }
 
 // Recenter map to location searched and update current coordinates

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -19,6 +19,7 @@ const mykey = keys.MAPS_API_KEY;
 document.getElementById('mapUrl').src = mykey;
 
 let player;
+let map;
 
 // When the page loads, call createMap
 window.onload = function() {
@@ -114,7 +115,7 @@ function displayCurrentStats(location, active, confirmed, deaths, recovered) {
 
 // Create a map zoomed in on Googleplex
 function createMap() {
-  const map = new google.maps.Map(
+  map = new google.maps.Map(
       document.getElementById('map'),
       {center: {lat: 39.496, lng: -99.031}, zoom: 5});
   // Gets active case data and displays as heat map
@@ -123,7 +124,7 @@ function createMap() {
     reports.forEach((report) => {
       heatmapData.push({
         location: new google.maps.LatLng(report.lat, report.lng),
-        weight: report.active,
+        weight: report.confirmed,
       });
       // Calculate worldwide data
       globalActive += report.active;
@@ -132,12 +133,21 @@ function createMap() {
       globalRecovered += report.recovered;
     });
     heatmap = new google.maps.visualization.HeatmapLayer(
-        {data: heatmapData, dissipating: false, map: map});
+        {data: heatmapData, dissipating: false, map: map, radius: 2.5});
     // Display worldwide data initially
     displayCurrentStats(
         'Worldwide', globalActive, globalConfirmed, globalDeaths,
         globalRecovered);
   });
+
+  // Switch heat on and off
+  function toggleHeatMap(heatmap) {
+    if (heatmap.getMap() == null) {
+      heatmap.setMap(map);
+    } else {
+      heatmap.setMap(null);
+    }
+  }
 
   const geocoder = new google.maps.Geocoder();
   document.getElementById('search-submit').addEventListener('click', () => {
@@ -153,6 +163,9 @@ function createMap() {
   });
   document.getElementById('videos').addEventListener('click', () => {
     searchForVideos(map);
+  });
+  document.getElementById('toggle-heat').addEventListener('click', () => {
+    toggleHeatMap(heatmap);
   });
   document.onkeypress = function(keyPressed) {
     const keyCodeForEnter = 13;

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -145,10 +145,10 @@ function createMap() {
         location: new google.maps.LatLng(report.lat, report.lng),
         weight: report.recovered,
       });
-      // populationHeatmapData.push({
-      // location: new google.maps.LatLng(report.lat, report.lng),
-      // weight: report.perCap,
-      //});
+      populationHeatmapData.push({
+        location: new google.maps.LatLng(report.lat, report.lng),
+        weight: report.perCap,
+      });
       // Calculate worldwide data
       globalActive += report.active;
       globalConfirmed += report.confirmed;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -45,11 +45,19 @@
   width: 20%;
 }
 
+#toggle-heat {
+  position: absolute;
+  display: inline-block;
+  z-index: 5;
+  top: 60px;
+}
+
 #my-location {
   position: absolute;
   display: inline-block;
   z-index: 5;
   top: 60px;
+  left: 127px;
 }
 
 #videos {
@@ -57,7 +65,7 @@
   display: inline-block;
   z-index: 5;
   top: 60px;
-  left: 127px;
+  left: 254px;
 }
 
 #location {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -49,47 +49,16 @@
   position: absolute;
   display: inline-block;
   z-index: 5;
-  top: 60px;
+  top: 21px;
+  right: 90px;
 }
 
-#toggle-confirmed {
+#heatMapType {
   position: absolute;
   display: inline-block;
   z-index: 5;
-  top: 60px;
-  left: 127px;
-}
-
-#toggle-active {
-  position: absolute;
-  display: inline-block;
-  z-index: 5;
-  top: 60px;
-  left: 254px;
-}
-
-#toggle-deaths {
-  position: absolute;
-  display: inline-block;
-  z-index: 5;
-  top: 60px;
-  left: 361px;
-}
-
-#toggle-recovered {
-  position: absolute;
-  display: inline-block;
-  z-index: 5;
-  top: 60px;
-  left: 488px;
-}
-
-#toggle-population {
-  position: absolute;
-  display: inline-block;
-  z-index: 5;
-  top: 60px;
-  left: 615px;
+  top: 22px;
+  right: 210px;
 }
 
 #my-location {
@@ -97,7 +66,6 @@
   display: inline-block;
   z-index: 5;
   top: 60px;
-  left: 742px;
 }
 
 #videos {
@@ -105,7 +73,7 @@
   display: inline-block;
   z-index: 5;
   top: 60px;
-  left: 869px;
+  left: 127px;
 }
 
 #location {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -52,7 +52,7 @@
   top: 60px;
 }
 
-#my-location {
+#toggle-confirmed {
   position: absolute;
   display: inline-block;
   z-index: 5;
@@ -60,12 +60,52 @@
   left: 127px;
 }
 
-#videos {
+#toggle-active {
   position: absolute;
   display: inline-block;
   z-index: 5;
   top: 60px;
   left: 254px;
+}
+
+#toggle-deaths {
+  position: absolute;
+  display: inline-block;
+  z-index: 5;
+  top: 60px;
+  left: 361px;
+}
+
+#toggle-recovered {
+  position: absolute;
+  display: inline-block;
+  z-index: 5;
+  top: 60px;
+  left: 488px;
+}
+
+#toggle-population {
+  position: absolute;
+  display: inline-block;
+  z-index: 5;
+  top: 60px;
+  left: 615px;
+}
+
+#my-location {
+  position: absolute;
+  display: inline-block;
+  z-index: 5;
+  top: 60px;
+  left: 742px;
+}
+
+#videos {
+  position: absolute;
+  display: inline-block;
+  z-index: 5;
+  top: 60px;
+  left: 869px;
 }
 
 #location {

--- a/src/test/java/com/google/sps/servlets/CasesDataServletTest.java
+++ b/src/test/java/com/google/sps/servlets/CasesDataServletTest.java
@@ -76,6 +76,7 @@ public final class CasesDataServletTest {
     Assert.assertTrue(reportsJson.contains("\"confirmed\""));
     Assert.assertTrue(reportsJson.contains("\"deaths\""));
     Assert.assertTrue(reportsJson.contains("\"recovered\""));
+    Assert.assertTrue(reportsJson.contains("\"perCap\""));
   }
 
   @Test


### PR DESCRIPTION
- Reduce the size of heat to show data more specifically
- Add option to toggle heatmap on/off
- Allow user to display active, confirmed, deaths, recovered, and per-capita case heatmaps
- Drop down menu for each heatmap type
- Confirmed cases heatmap initially displayed